### PR TITLE
fix: decouple weakAnd targetHits from page size for stable ranking

### DIFF
--- a/lib/vespa_ruby/simple_query.rb
+++ b/lib/vespa_ruby/simple_query.rb
@@ -6,18 +6,30 @@ require "active_support/core_ext/object/blank"
 
 module VespaRuby
   class SimpleQuery < YqlQuery
+    # A weakAnd produced by the query parser (model.type=weakAnd + userQuery())
+    # gets its targetHits from the requested `hits`, so ranking depends on the
+    # page size: a larger `hits` widens the candidate pool and reshuffles the top
+    # results, and because targetHits is per content node, deployments with
+    # different node counts diverge too. We instead realize weakAnd via
+    # weakAnd.replace + a fixed wand.hits, decoupling the candidate pool from the
+    # page size so ranking is stable and reproducible. Large enough that the
+    # per-node pool comfortably covers any page we return.
+    DEFAULT_WEAK_AND_TARGET_HITS = 1000
+
     # See https://docs.vespa.ai/en/reference/query-api-reference.html#query-model
     # Not supporting model.encoding, model.locale, model.language, model.searchPath
     attr_reader :model_query_string_value,
       :model_default_index,
       :model_filter,
-      :model_type #: String?
+      :model_type, #: String?
+      :target_hits_value #: Integer?
 
     def initialize
       @model_query_string_value = nil
       @model_default_index = nil
       @model_filter = nil
       @model_type = nil
+      @target_hits_value = nil
 
       super
     end
@@ -75,7 +87,6 @@ module VespaRuby
       self
     end
 
-    # TODO: Add {targetHits: #{params[:limit] * 10}} to weakAnd queries. Default is 100.
     # See https://docs.vespa.ai/en/reference/simple-query-language-reference.html
     #: (String) -> YqlQuery
     def type(type = "all")
@@ -86,16 +97,46 @@ module VespaRuby
       self
     end
 
-    #: () -> Hash[Symbol|String, String?]?
+    # Override the fixed weakAnd targetHits (default DEFAULT_WEAK_AND_TARGET_HITS).
+    # Only takes effect for weakAnd queries.
+    #: (Integer) -> YqlQuery
+    def target_hits(hits)
+      @target_hits_value = hits
+
+      self
+    end
+
+    #: () -> Hash[Symbol|String, untyped]
     def build_query_model_hash
-      {
+      hash = {
         "model.queryString": @model_query_string_value,
         "model.defaultIndex": @model_default_index,
         "model.filter": @model_filter,
         "model.restrict": @model_restrict,
         "model.sources": @model_sources,
         "model.type": @model_type
-      }.compact!
+      }
+
+      # Realize weakAnd through weakAnd.replace so we control its targetHits (see
+      # DEFAULT_WEAK_AND_TARGET_HITS). There is no Vespa knob for the targetHits of
+      # the weakAnd that model.type=weakAnd + userQuery() generates, so instead we:
+      #   1. model.type=any   -> userQuery() parses the terms into a plain OR
+      #   2. weakAnd.replace  -> Vespa rewrites every OR in the tree into a weakAnd
+      #   3. wand.hits=N      -> those rewritten weakAnds get a FIXED targetHits
+      # Net: identical weakAnd matching, but the candidate pool is a constant N per
+      # node instead of the page size.
+      #
+      # Caveat: weakAnd.replace is blunt -- it converts ALL ORs in the tree, incl.
+      # any filter-side OR. Harmless here because a weakAnd with targetHits=N over a
+      # few filter clauses never fills its heap, so it skips nothing and behaves
+      # exactly like OR.
+      if @model_type == "weakAnd"
+        hash[:"model.type"] = "any"
+        hash[:"weakAnd.replace"] = true
+        hash[:"wand.hits"] = @target_hits_value || DEFAULT_WEAK_AND_TARGET_HITS
+      end
+
+      hash.compact
     end
 
     #: (Hash[untyped, untyped]) -> String

--- a/lib/vespa_ruby/where_op.rb
+++ b/lib/vespa_ruby/where_op.rb
@@ -39,7 +39,9 @@ module VespaRuby
     def self.wand(arguments, annotations: {})
       raise ArgumentError("wand requires at least two arguments") unless arguments.is_a?(Array) && arguments.length > 1
 
-      phrase = "wand(#{arguments.map(&:to_s).join(", ")})"
+      # map(&:to_s) keeps nested [term, weight] pairs bracketed; a bare join would
+      # flatten them ("[11, 1], [37, 2]" vs "11, 1, 37, 2"), so the cop is wrong here.
+      phrase = "wand(#{arguments.map(&:to_s).join(", ")})" # standard:disable Style/MapJoin
 
       annotations.empty? ? phrase : build_annotations(annotations, phrase)
     end

--- a/test/test_simple_query.rb
+++ b/test/test_simple_query.rb
@@ -62,5 +62,42 @@ module VespaRuby
       assert_equal "bm25_anc_heavy", request.post_body[:"ranking.profile"]
       assert_equal "ranktext", request.post_body[:"model.defaultIndex"]
     end
+
+    test "weakAnd uses a fixed targetHits decoupled from hits" do
+      q = SimpleQuery.query("qualified business income deduction")
+        .select("id").from("division").type("weakAnd")
+        .where(WhereOp.contains("jurisdiction", "FED"))
+
+      b1 = q.build_request(options: {hits: 1}).post_body
+      b50 = q.build_request(options: {hits: 50}).post_body
+
+      # weakAnd is realized via weakAnd.replace so its targetHits is controllable
+      assert_equal "any", b1[:"model.type"]
+      assert_equal true, b1[:"weakAnd.replace"]
+
+      # the bug: targetHits tracked hits. Now it must NOT change with the page size
+      assert_equal b1[:"wand.hits"], b50[:"wand.hits"]
+      # ...and be large enough that the pool isn't the page size
+      assert_operator b50[:"wand.hits"], :>=, 500
+      # the page size itself still varies as requested
+      assert_equal 1, b1[:hits]
+      assert_equal 50, b50[:hits]
+    end
+
+    test "target_hits overrides the default weakAnd targetHits" do
+      q = SimpleQuery.query("meal break").select("id").from("division")
+        .type("weakAnd").target_hits(2000)
+
+      assert_equal 2000, q.build_request(options: {hits: 20}).post_body[:"wand.hits"]
+    end
+
+    test "non-weakAnd queries emit no weakAnd params" do
+      body = SimpleQuery.query("meal break").select("id").from("division")
+        .type("all").build_request(options: {hits: 20}).post_body
+
+      assert_equal "all", body[:"model.type"]
+      assert_nil body[:"weakAnd.replace"]
+      assert_nil body[:"wand.hits"]
+    end
   end
 end


### PR DESCRIPTION
## Problem

Keyword search ranking is **unstable**. For the *same query*, results reshuffle as the `limit`/`hits` parameter changes, and they differ between production and staging.

**Root cause:** a `weakAnd` built by the query parser (`model.type=weakAnd` + `userQuery()`) has no exposed knob for its `targetHits`, so Vespa ties it to the requested `hits` (= the API `limit`). `weakAnd` only exposes its `targetHits` best-by-term-score candidates to first-phase ranking, so a larger `limit` widens the candidate pool and reorders the top results. And because `targetHits` is **per content node**, deployments with different node counts (prod vs staging) diverge too. (This is the gem's own `# TODO` at `simple_query.rb` — "Add `{targetHits: …}` to weakAnd queries".)

### Evidence (production)
Query `qualified business income deduction` on FED-USC — rank of the exact-title match `26 U.S.C. § 199A`:

| `limit` | rank of § 199A |
|--------:|:--|
| 1  | **1** |
| 5  | 5 |
| 10 | 8 |
| 20 | **17** |

Prod vs staging on 24 calls: 3/24 identical, mean set-overlap 79.4% — a path-existence check confirmed **0 corpus gaps** (every divergent doc exists on both sides), i.e. pure ranking churn, not an index-sync problem.

## Fix

There is no Vespa request parameter that sets `targetHits` for the auto-generated `userQuery()` weakAnd, and rebuilding the weakAnd in YQL by hand would lose `userQuery()`'s linguistics (tokenization, stemming, `+`/`-` operators). So we realize weakAnd the controllable way instead:

1. `model.type=any` → `userQuery()` parses the terms into a plain **OR**
2. `weakAnd.replace=true` → Vespa rewrites every OR in the tree into a **weakAnd**
3. `wand.hits=N` → those rewritten weakAnds get a **fixed** `targetHits` (default `DEFAULT_WEAK_AND_TARGET_HITS = 1000`, overridable per query via `#target_hits`)

Net: identical weakAnd matching semantics, but the candidate pool is a constant per node instead of the page size — so the top-N is a **stable prefix** across limits and reproducible across deployments. 1000 is large enough that node-count differences no longer move docs in/out of the returned window.

**Public API unchanged:** callers still use `.type("weakAnd")`.

### Caveat
`weakAnd.replace` is blunt — it converts *all* ORs in the tree, including any filter-side OR. This is harmless: a `weakAnd` with `targetHits=1000` over a handful of filter clauses never fills its heap, so it skips nothing and behaves exactly like OR.

## Tests
Three deterministic, no-network unit tests in `test/test_simple_query.rb`:
- weakAnd `wand.hits` is identical for `hits: 1` vs `hits: 50` (decoupled from page size) and `>= 500`
- `#target_hits` overrides the default
- non-weakAnd queries emit no weakAnd params

Verified these go **red** against the unfixed code (model.type stays `weakAnd`; `#target_hits` missing) and **green** with the fix. Full `rake` (Minitest + `standard`): **66 runs, 0 failures, 0 errors**, 0 offenses.

## Drive-by
Silenced a pre-existing false-positive `Style/MapJoin` on `WhereOp.wand` — `map(&:to_s)` is load-bearing there (it keeps nested `[term, weight]` pairs bracketed; a bare `join` flattens them), and it was the only thing failing the `rake` default `standard` task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)