### PR TITLE
fix(security): escape quotes and backslashes in YQL string literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+## [0.5.2]
+
+- **Security:** escape `"` and `\` in double-quoted YQL string literals
+  (`QueryHelper#double_quoted_string` and `#quoted_array`). Previously a value
+  containing a double quote — e.g. a caller passing user input as a `WhereOp.contains`,
+  `WhereOp.in`, or `WhereOp.phrase` argument — could break out of the string literal and
+  inject arbitrary YQL into the `where` clause. The free-text `model.queryString`
+  (`userQuery()`) path was never affected; this only concerns values interpolated into
+  the YQL string itself.
+
 ## [0.5.1]
 
 - Fix `WhereOp.wand` raising `NoMethodError` instead of `ArgumentError` on fewer than two

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    vespa_ruby (0.5.1)
+    vespa_ruby (0.5.2)
       activesupport
       faraday (< 3.a)
       logging

--- a/lib/vespa_ruby/query_helper.rb
+++ b/lib/vespa_ruby/query_helper.rb
@@ -16,7 +16,17 @@ module VespaRuby
 
     #: (String) -> String
     def double_quoted_string(original)
-      unquoted?(original) ? original : "\"#{original}\""
+      unquoted?(original) ? original : "\"#{escape_yql_string(original)}\""
+    end
+
+    # Escape the characters that would otherwise let a value break out of a
+    # double-quoted YQL string literal: a bare `"` closes the literal and a bare
+    # `\` starts an escape sequence. Without this, an attacker-supplied field
+    # value (e.g. a caller passing user input as a `contains` argument) can inject
+    # arbitrary YQL. Backslash-prefix both in a single pass over the original.
+    #: (String) -> String
+    def escape_yql_string(original)
+      original.to_s.gsub(/[\\"]/) { |char| "\\#{char}" }
     end
 
     #: (Numeric|TrueClass|FalseClass|String) -> bool
@@ -29,7 +39,7 @@ module VespaRuby
 
     #: (Array[String]) -> Array[String]
     def quoted_array(original)
-      original.collect { |v| "\"#{v}\"" }
+      original.collect { |v| "\"#{escape_yql_string(v)}\"" }
     end
 
     # See https://docs.vespa.ai/en/reference/query-language-reference.html#annotations

--- a/lib/vespa_ruby/version.rb
+++ b/lib/vespa_ruby/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module VespaRuby
-  VERSION = "0.5.1"
+  VERSION = "0.5.2"
 end

--- a/sig/generated/vespa_ruby/query_helper.rbs
+++ b/sig/generated/vespa_ruby/query_helper.rbs
@@ -8,6 +8,14 @@ module VespaRuby
     # : (String) -> String
     def double_quoted_string: (String) -> String
 
+    # Escape the characters that would otherwise let a value break out of a
+    # double-quoted YQL string literal: a bare `"` closes the literal and a bare
+    # `\` starts an escape sequence. Without this, an attacker-supplied field
+    # value (e.g. a caller passing user input as a `contains` argument) can inject
+    # arbitrary YQL. Backslash-prefix both in a single pass over the original.
+    # : (String) -> String
+    def escape_yql_string: (String) -> String
+
     # : (Numeric|TrueClass|FalseClass|String) -> bool
     def unquoted?: (Numeric | TrueClass | FalseClass | String) -> bool
 

--- a/test/test_query_helper.rb
+++ b/test/test_query_helper.rb
@@ -34,6 +34,25 @@ module VespaRuby
       assert_equal "\"abc\"", result
     end
 
+    test "double_quoted_string escapes embedded quotes and backslashes" do
+      # A bare " would close the literal and inject YQL; it must be backslash-escaped.
+      assert_equal "\"a\\\"b\"", @dummy.double_quoted_string("a\"b")
+      # A bare \ starts an escape sequence; it must itself be escaped.
+      assert_equal "\"a\\\\b\"", @dummy.double_quoted_string("a\\b")
+      # The canonical injection attempt: break out and OR in a new clause.
+      assert_equal "\"A\\\" or lawKey contains \\\"B\"",
+        @dummy.double_quoted_string("A\" or lawKey contains \"B")
+    end
+
+    test "escape_yql_string leaves ordinary values untouched" do
+      assert_equal "CA-STAT", @dummy.escape_yql_string("CA-STAT")
+      assert_equal "title_15.division_1.chapter_1", @dummy.escape_yql_string("title_15.division_1.chapter_1")
+    end
+
+    test "quoted_array escapes each element" do
+      assert_equal ["\"a\\\"b\"", "\"c\\\\d\""], @dummy.quoted_array(["a\"b", "c\\d"])
+    end
+
     test "unquoted?" do
       refute @dummy.unquoted?("a")
 

--- a/test/test_where_op.rb
+++ b/test/test_where_op.rb
@@ -10,6 +10,17 @@ module VespaRuby
       assert_equal "a contains 1", op_contains_num
     end
 
+    test "contains escapes a value that tries to break out of the string literal" do
+      # Without escaping this injects a second clause: a contains "x" or true or "".
+      op = WhereOp.contains("a", "x\" or true or \"")
+      assert_equal "a contains \"x\\\" or true or \\\"\"", op
+    end
+
+    test "in escapes string members" do
+      op = WhereOp.in("lawKey", ["CA-STAT", "x\" or true or \""])
+      assert_equal "lawKey in (\"CA-STAT\", \"x\\\" or true or \\\"\")", op
+    end
+
     # NOTE: no test for annotated non-String values as there are no valid use cases yet. It looks like the intention was
     # for numeric values, but the interface can also be used with custom objects that implement their own to_s. As a
     # side note, functions could also be on the right side. I think it would make sense in that case to implement as a


### PR DESCRIPTION
double_quoted_string and quoted_array wrapped values in double quotes without escaping an embedded " or \. Any caller that passes user-controlled input as a WhereOp.contains / WhereOp.in / WhereOp.phrase argument could break out of the string literal and inject arbitrary YQL into the where clause. The free-text model.queryString (userQuery()) path is a bound parameter and was never affected.

Escape " and \ at the single quoting chokepoint so every WhereOp string literal is inert regardless of the caller. Ordinary values (law keys, ltree paths, numerics, booleans) are unchanged.